### PR TITLE
refactor context provider

### DIFF
--- a/src/components/common/NavBar/index.tsx
+++ b/src/components/common/NavBar/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { Button } from '@mui/material'
+import Button from '@mui/material/Button'
 import Link from 'next/link'
 import React from 'react'
 

--- a/src/components/manageProject/ManageProject/index.tsx
+++ b/src/components/manageProject/ManageProject/index.tsx
@@ -1,7 +1,7 @@
 import { useUser } from '@auth0/nextjs-auth0'
 import React from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
+import isReadOnlyContext from '../../../context/isReadOnlyContext'
 import Loader from '../../common/Loader'
 import ProjectHeading from '../ProjectHeading'
 import ProjectMain from '../ProjectMain'
@@ -23,7 +23,7 @@ const ManageProject = ({ data, isReadOnly }: Props) => {
 
   const userId = user?.sub?.split('|')[1]
   return (
-    <ProjectIsReadOnlyContext.Provider value={isReadOnly}>
+    <isReadOnlyContext.Provider value={isReadOnly}>
       <div className="max-w-5xl mx-auto w-full lg:min-h-screen lg:flex lg:flex-col">
         <ProjectHeading data={data} userId={userId} />
         <div className="flex flex-col-reverse lg:grid lg:grid-cols-profile lg:flex-1">
@@ -31,7 +31,7 @@ const ManageProject = ({ data, isReadOnly }: Props) => {
           <ProjectMain data={data} userId={userId} />
         </div>
       </div>
-    </ProjectIsReadOnlyContext.Provider>
+    </isReadOnlyContext.Provider>
   )
 }
 

--- a/src/components/manageProject/ManageProject/index.tsx
+++ b/src/components/manageProject/ManageProject/index.tsx
@@ -1,7 +1,7 @@
 import { useUser } from '@auth0/nextjs-auth0'
 import React from 'react'
 
-import isReadOnlyContext from '../../../context/isReadOnlyContext'
+import { isReadOnlyContext } from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 import ProjectHeading from '../ProjectHeading'
 import ProjectMain from '../ProjectMain'

--- a/src/components/manageProject/ProjectBudget/index.tsx
+++ b/src/components/manageProject/ProjectBudget/index.tsx
@@ -4,11 +4,11 @@ import Button from '@mui/material/Button'
 import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import TextField from '@mui/material/TextField'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import GET_CURRENCIES from '../../../gql/country'
 import { UPDATE_PROJECT_BUDGET } from '../../../gql/project'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 import RadioButtonsGroup from '../../common/RadioButtonsGroup'
@@ -16,7 +16,7 @@ import RadioButtonsGroup from '../../common/RadioButtonsGroup'
 const ProjectBudget = ({ data, userId, projectId }) => {
   const { error, loading, data: countryData } = useQuery(GET_CURRENCIES)
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(ProjectIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
   const [projectBudget, setProjectBudget] = useState(data)
   const [updatedBudget, setUpdatedBudget] = useState<string | null>(null)
 

--- a/src/components/manageProject/ProjectDescription/index.tsx
+++ b/src/components/manageProject/ProjectDescription/index.tsx
@@ -2,17 +2,17 @@ import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_PROJECT_DESCRIPTION } from '../../../gql/project'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 
 const ProjectDescription = ({ data, userId, projectId }) => {
   const [projectDescription, setProjectDescription] = useState<string>(data)
   const [updatedDescription, setUpdatedDescription] = useState<string | null>(null)
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(ProjectIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [updateProjectDescription, { loading, error }] = useMutation(UPDATE_PROJECT_DESCRIPTION, {
     onCompleted(val) {

--- a/src/components/manageProject/ProjectScope/index.tsx
+++ b/src/components/manageProject/ProjectScope/index.tsx
@@ -1,17 +1,17 @@
 import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_PROJECT_SCOPE } from '../../../gql/project'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 import RadioButtonsGroup from '../../common/RadioButtonsGroup'
 
 const ProjectScope = ({ data, userId, projectId }) => {
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(ProjectIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [projectScope, setProjectScope] = useState(data)
   const [updatedScope, setUpdatedScope] = useState<string | null>(null)

--- a/src/components/manageProject/ProjectSkills/index.tsx
+++ b/src/components/manageProject/ProjectSkills/index.tsx
@@ -1,10 +1,10 @@
 import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_PROJECT_SKILLS } from '../../../gql/project'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { icons } from '../../../lib/icon'
 import Loader from '../../common/Loader'
 import SkillIcons from '../../common/SkillIcons'
@@ -13,7 +13,7 @@ const ProjectSkills = ({ data, userId, projectId }) => {
   const [projectSkills, setProjectSkills] = useState<any>(data)
   const [updatedSkills, setUpdatedSkills] = useState<any | null>(null)
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(ProjectIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   useEffect(() => {
     setProjectSkills(data)

--- a/src/components/manageProject/ProjectTitle/index.tsx
+++ b/src/components/manageProject/ProjectTitle/index.tsx
@@ -2,17 +2,17 @@ import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { ProjectIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_PROJECT_TITLE } from '../../../gql/project'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 
 const ProjectTitle = ({ data, userId, projectId }) => {
   const [projectTitle, setProjectTitle] = useState<string>(data)
   const [updatedTitle, setUpdatedTitle] = useState<string | null>(null)
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(ProjectIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   useEffect(() => {
     setProjectTitle(data)

--- a/src/components/profile/Bio/index.tsx
+++ b/src/components/profile/Bio/index.tsx
@@ -2,15 +2,15 @@ import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_BIO } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 
 const Bio = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [bio, setBio] = useState<null | String>(data)
   const [updatedBio, setUpdatedBio] = useState(null)

--- a/src/components/profile/Contacts/index.tsx
+++ b/src/components/profile/Contacts/index.tsx
@@ -8,10 +8,10 @@ import RoomIcon from '@mui/icons-material/Room'
 import TwitterIcon from '@mui/icons-material/Twitter'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_CONTACT } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 
@@ -26,7 +26,7 @@ interface ContactObj {
 
 const Contacts = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [contact, setContact] = useState<ContactObj>(data)
   const [updatedContact, setUpdatedContact] = useState(null)

--- a/src/components/profile/ContriesICanWork/index.tsx
+++ b/src/components/profile/ContriesICanWork/index.tsx
@@ -6,17 +6,17 @@ import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
-import React, { FormEvent, useContext, useState } from 'react'
+import React, { FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_COUNTRIESICANWORK } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
 
 const CountriesICanWork = ({ data, countries }) => {
   const [edit, setEdit] = useState<boolean>(!data)
   const [popUp, setPopup] = useState({ show: false, index: null })
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
   const [countriesICanWork, setCountriesICanWork] = useState<any[]>(data)
   const [updatedCountriesICanWork, setupdatedCountriesICanWork] = useState(null)
 

--- a/src/components/profile/DeveloperCommunityInvolement/index.tsx
+++ b/src/components/profile/DeveloperCommunityInvolement/index.tsx
@@ -5,10 +5,10 @@ import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_DEVELOPERCOMUNITYINVOLVEMENT } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
@@ -23,7 +23,7 @@ interface developerCommunityInvolementObj {
 const DeveloperCommunityInvolement = ({ data }) => {
   const [popUp, setPopup] = useState({ show: false, index: null })
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [developerCommunityInvolement, setDeveloperCommunityInvolement] =
     useState<developerCommunityInvolementObj[]>(data)

--- a/src/components/profile/DisplayPicture/index.tsx
+++ b/src/components/profile/DisplayPicture/index.tsx
@@ -3,10 +3,10 @@ import { useMutation } from '@apollo/client'
 import DeleteIcon from '@mui/icons-material/Delete'
 import IconButton from '@mui/material/IconButton'
 import Axios from 'axios'
-import React, { useContext, useState } from 'react'
+import React, { useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_AVATAR } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Avatar from '../../common/Avatar'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
@@ -14,7 +14,7 @@ import DeleteAlert from '../DeleteAlert'
 const DisplayPicture = ({ data }) => {
   const [popUp, setPopup] = useState<boolean>(false)
   const [picture, setPicture] = useState<URL | null>(data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [updateUserPicture, { loading, error }] = useMutation(UPDATE_USER_AVATAR)
 

--- a/src/components/profile/Education/index.tsx
+++ b/src/components/profile/Education/index.tsx
@@ -8,11 +8,11 @@ import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 import DatePicker from 'react-datepicker'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_EDUCATION } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
@@ -27,7 +27,7 @@ interface educationObj {
 const Education = ({ data }) => {
   const [popUp, setPopup] = useState({ show: false, index: null })
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [education, setEducation] = useState<educationObj[]>(data)
   const [updatedEducation, setUpdatedEducation] = useState(null)

--- a/src/components/profile/Hobbies/index.tsx
+++ b/src/components/profile/Hobbies/index.tsx
@@ -2,10 +2,10 @@
 import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_HOBBIES } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
 import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
@@ -13,7 +13,7 @@ import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
 const Hobbies = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
   const [popUp, setPopup] = useState({ show: false, index: null })
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [hobbies, setHobbies] = useState<any>(data || [])
   const [updatedHobbies, setUpdatedHobbies] = useState(null)

--- a/src/components/profile/Languages/index.tsx
+++ b/src/components/profile/Languages/index.tsx
@@ -3,10 +3,10 @@
 import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_LANGUAGES } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
 import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
@@ -14,7 +14,7 @@ import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
 const Language = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
   const [popUp, setPopup] = useState({ show: false, index: null })
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [languages, setLanguages] = useState<string[]>(data)
   const [updatedLanguages, setUpdatedLanguages] = useState(null)

--- a/src/components/profile/ProfessinalExperience/index.tsx
+++ b/src/components/profile/ProfessinalExperience/index.tsx
@@ -10,11 +10,11 @@ import Checkbox from '@mui/material/Checkbox'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import IconButton from '@mui/material/IconButton'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 import DatePicker from 'react-datepicker'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_PROFESSIONALEXPERIENCE } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { icons } from '../../../lib/icon'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
@@ -37,7 +37,7 @@ interface professionalExperienceObj {
 const ProfessionalExperience = ({ data }) => {
   const [popUp, setPopup] = useState({ show: false, index: null })
   const [edit, setEdit] = useState<boolean | number>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [professionalExp, setProfessionalExp] = useState<professionalExperienceObj[]>(data)
   const [updatedProfessionalExp, setupdatedProfessionalExp] = useState(null)

--- a/src/components/profile/Profile/index.tsx
+++ b/src/components/profile/Profile/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import isReadOnlyContext from '../../../context/isReadOnlyContext'
+import { isReadOnlyContext } from '../../../hooks/useIsReadOnlyContext'
 import Heading from '../Heading'
 import ProfileMain from '../ProfileMain'
 import ProfileSidebar from '../ProfileSidebar'

--- a/src/components/profile/Profile/index.tsx
+++ b/src/components/profile/Profile/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
+import isReadOnlyContext from '../../../context/isReadOnlyContext'
 import Heading from '../Heading'
 import ProfileMain from '../ProfileMain'
 import ProfileSidebar from '../ProfileSidebar'
@@ -17,7 +17,7 @@ const defaultProps = {
 }
 
 const Profile = ({ countries, data, isReadOnly }: Props) => (
-  <UserIsReadOnlyContext.Provider value={isReadOnly}>
+  <isReadOnlyContext.Provider value={isReadOnly}>
     <div className="max-w-5xl mx-auto w-full">
       <Heading data={data} />
       <div className="flex flex-col-reverse lg:grid lg:grid-cols-profile   lg:min-h-screen ">
@@ -29,7 +29,7 @@ const Profile = ({ countries, data, isReadOnly }: Props) => (
         <ProfileMain data={data} page={2} />
       </div>
     </div>
-  </UserIsReadOnlyContext.Provider>
+  </isReadOnlyContext.Provider>
 )
 export default Profile
 

--- a/src/components/profile/Skills/index.tsx
+++ b/src/components/profile/Skills/index.tsx
@@ -6,10 +6,10 @@ import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Slider from '@mui/material/Slider'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_SKILLS } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import { removeKey } from '../../../lib/utils'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
@@ -22,7 +22,7 @@ interface SkillsObj {
 const Skills = ({ data }) => {
   const [popUp, setPopup] = useState({ show: false, index: null })
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [skills, setSkills] = useState<SkillsObj[]>(data)
   const [updatedSkills, setUpdatedSkills] = useState(null)

--- a/src/components/profile/Sport/index.tsx
+++ b/src/components/profile/Sport/index.tsx
@@ -2,10 +2,10 @@
 import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_SPORTS } from '../../../gql/user'
+import useIsReadOnlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 import DeleteAlert from '../DeleteAlert'
 import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
@@ -13,7 +13,7 @@ import TextFieldAndDeleteBtn from '../TextFieldAndDeleteBtn'
 const Sport = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
   const [popUp, setPopup] = useState({ show: false, index: null })
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadOnlyContext()
 
   const [sports, setSports] = useState(data || [])
   const [updatedSports, setUpdatedSports] = useState(null)

--- a/src/components/profile/UserNameTitle/index.tsx
+++ b/src/components/profile/UserNameTitle/index.tsx
@@ -2,10 +2,10 @@ import { useMutation } from '@apollo/client'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
-import React, { ChangeEvent, FormEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
-import { UserIsReadOnlyContext } from '../../../context/isReadOnlyContext'
 import { UPDATE_USER_NAMETITLE } from '../../../gql/user'
+import useIsReadonlyContext from '../../../hooks/useIsReadOnlyContext'
 import Loader from '../../common/Loader'
 
 interface UserObj {
@@ -15,7 +15,7 @@ interface UserObj {
 
 const UserNameTitle = ({ data }) => {
   const [edit, setEdit] = useState<boolean>(!data)
-  const isReadOnly = useContext(UserIsReadOnlyContext)
+  const isReadOnly = useIsReadonlyContext()
 
   const [nameTitle, setNameTitle] = useState<UserObj>(data)
   const [updatedNameTitle, setUpdatedNameTitle] = useState<string | null>(null)

--- a/src/components/projects/Projects/index.tsx
+++ b/src/components/projects/Projects/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import React from 'react'
 
 import MasterDetailsLayout from '../../common/MasterDetailsLayout'

--- a/src/context/isReadOnlyContext.ts
+++ b/src/context/isReadOnlyContext.ts
@@ -1,4 +1,0 @@
-import { createContext } from 'react'
-
-const isReadOnlyContext = createContext(true)
-export default isReadOnlyContext

--- a/src/context/isReadOnlyContext.ts
+++ b/src/context/isReadOnlyContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+
+const isReadOnlyContext = createContext(true)
+export default isReadOnlyContext

--- a/src/context/isReadOnlyContext.tsx
+++ b/src/context/isReadOnlyContext.tsx
@@ -1,5 +1,0 @@
-import { createContext } from 'react'
-
-export const ProjectIsReadOnlyContext = createContext(null)
-
-export const UserIsReadOnlyContext = createContext(null)

--- a/src/hooks/useIsReadOnlyContext.ts
+++ b/src/hooks/useIsReadOnlyContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+
+import isReadOnlyContext from '../context/isReadOnlyContext'
+
+function useIsReadOnlyContext() {
+  const isReadOnly = useContext(isReadOnlyContext)
+  return isReadOnly
+}
+
+export default useIsReadOnlyContext

--- a/src/hooks/useIsReadOnlyContext.ts
+++ b/src/hooks/useIsReadOnlyContext.ts
@@ -1,6 +1,6 @@
-import { useContext } from 'react'
+import { createContext, useContext } from 'react'
 
-import isReadOnlyContext from '../context/isReadOnlyContext'
+export const isReadOnlyContext = createContext(true)
 
 function useIsReadOnlyContext() {
   const isReadOnly = useContext(isReadOnlyContext)


### PR DESCRIPTION
- Use a single context provider instead of multiple which does the same thing 
- create a custom hook to provide context to components. Instead of having to import useContext again and again. 